### PR TITLE
Simplify exercise import by filtering via API

### DIFF
--- a/app/src/de/skubware/opentraining/activity/settings/sync/OpenTrainingSyncService.java
+++ b/app/src/de/skubware/opentraining/activity/settings/sync/OpenTrainingSyncService.java
@@ -61,7 +61,7 @@ public class OpenTrainingSyncService extends IntentService {
 	public static final String EXTRA_HOST = "host";
 	
 	/** The path for getting the exercises as JSON */
-	public static final String EXERCISE_REQUEST_PATH = "/api/v1/exercise/?limit=1000";
+	public static final String EXERCISE_REQUEST_PATH = "/api/v1/exercise/?status__in=2,4,5&limit=0";
 	/** The path for getting the languages as JSON */
 	public static final String LANGUAGE_REQUEST_PATH = "/api/v1/language/";
 	/** The path for getting the muscles as JSON */

--- a/app/src/de/skubware/opentraining/activity/settings/sync/WgerJSONParser.java
+++ b/app/src/de/skubware/opentraining/activity/settings/sync/WgerJSONParser.java
@@ -93,14 +93,6 @@ public class WgerJSONParser {
 			String name = jsonExercise.getString("name");
 			if(dataProvider.exerciseExists(name))
 				continue;
-
-			// status - used for sorting out not authorized/refused exercises
-			// (1: not authorized, means that a user suggested it but it hasn't been
-			// checked by the admin yet; 3: refused)
-			Integer status = jsonExercise.getInt("status");
-			if(status == 1 || status == 3)
-				continue;
-			
 			
 			ExerciseType.Builder builder = new ExerciseType.Builder(name);
 			


### PR DESCRIPTION
Remove some client-side logic, most of the API fields now allow filtering.
